### PR TITLE
Update Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-django = "==1.11.15"
+django = "==1.11.18"
 "argon2-cffi" = "*"
 django-allauth = "*"
 django-widget-tweaks = "*"


### PR DESCRIPTION
セキュリティ上の問題(CVE-2019-3498)からDjangoのバージョンを1.11.15から1.11.18へバージョンアップ